### PR TITLE
feat: E2Eテストスイートの実装と修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:unit": "vitest run -c vitest.config.ts",
     "test:e2e": "pnpm exec playwright-core install && vitest run -c vitest.config.e2e.ts",
-    "test:ui": "vitest --ui",
+    "test:ui": "vitest --ui -c vitest.config.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -4,26 +4,21 @@ import { setup, createPage, url } from '@nuxt/test-utils/e2e'
 import * as dotenv from 'dotenv'
 
 // Load environment variables for local testing.
-// In GitHub Actions, these variables are set as secrets.
 dotenv.config()
 
-describe('Nuxt Livesync E2E Test', async () => {
-  // Setup the Nuxt test environment.
-  // This will start a server with the Nuxt application.
-  await setup({
-    // browser: true, // Uncomment to run in browser context
-    // browserOptions: {
-    //   type: 'chromium',
-    //   launch: {
-    //     headless: true, // Run in headless mode
-    //   },
-    // },
-  })
+describe('Nuxt Livesync E2E Test', () => {
+  // Setup the Nuxt test environment before all tests.
+  // Allow a long timeout for the initial setup, especially on CI.
+  beforeAll(async () => {
+    await setup()
+  }, 60000)
 
   describe('Scenario 1: Admin Authentication Flow', () => {
     it('1.1: Unauthenticated user should be redirected to login page', async () => {
       const page = await createPage()
       await page.goto(url('/admin/cues'), { waitUntil: 'networkidle' })
+      // Expect to be redirected to the login page and see the login header.
+      await expect(page.getByRole('heading', { name: '管理者ログイン' })).toBeVisible()
       expect(page.url()).toContain('/admin/login')
       await page.close()
     })
@@ -32,15 +27,15 @@ describe('Nuxt Livesync E2E Test', async () => {
       const page = await createPage()
       await page.goto(url('/admin/login'), { waitUntil: 'networkidle' })
 
-      // Input credentials
+      // Input credentials from .env file
       await page.fill('input[name="email"]', process.env.SUPABASE_TEST_EMAIL || '')
       await page.fill('input[name="password"]', process.env.SUPABASE_TEST_PASSWORD || '')
 
       // Click the login button
       await page.click('button[type="submit"]')
 
-      // Wait for navigation and check the URL
-      await page.waitForURL('**/admin/cues')
+      // Wait for navigation by checking for a specific element on the destination page.
+      await expect(page.getByRole('heading', { name: '演出管理' })).toBeVisible()
       expect(page.url()).toContain('/admin/cues')
 
       await page.close()
@@ -50,6 +45,7 @@ describe('Nuxt Livesync E2E Test', async () => {
   describe('Scenario 2: Cue Management (CRUD) Flow', () => {
     let page: Page
 
+    // Log in once before running all tests in this describe block.
     beforeAll(async () => {
       page = await createPage()
       await page.goto(url('/admin/login'), { waitUntil: 'networkidle' })
@@ -57,103 +53,106 @@ describe('Nuxt Livesync E2E Test', async () => {
       await page.fill('input[name="email"]', process.env.SUPABASE_TEST_EMAIL || '')
       await page.fill('input[name="password"]', process.env.SUPABASE_TEST_PASSWORD || '')
       await page.click('button[type="submit"]')
-      await page.waitForURL('**/admin/cues')
+
+      // Wait for the heading to be visible, confirming login and navigation.
+      await expect(page.getByRole('heading', { name: '演出管理' })).toBeVisible()
     })
 
     afterAll(async () => {
       await page.close()
     })
 
-    const cueName = `E2E Test Cue ${Date.now()}`
-    const updatedCueName = `${cueName}-updated`
+    const cueName = `Test Cue 1`
+    const updatedCueName = `Updated Cue Name`
 
     it('2.1: Create a new cue', async () => {
-      // Click 'Add New Cue' button
+      // Click 'Add New Cue' button.
       await page.getByRole('button', { name: '新規演出を追加' }).click()
 
-      // Fill in the dialog
+      // Fill in the dialog.
       await page.getByLabel('演出名').fill(cueName)
       await page.getByLabel('種類').selectOption({ label: '単色' })
       await page.getByLabel('値').fill('#ff00ff')
       await page.getByRole('button', { name: '保存' }).click()
 
-      // Verify the new cue is in the table
-      await expect(page.getByText(cueName)).toBeVisible()
+      // Verify the new cue is visible in the table.
+      await expect(page.getByRole('row', { name: cueName })).toBeVisible()
     })
 
     it('2.2: Edit the cue', async () => {
-      // Find the row and click the 'Edit' button
+      // Find the row and click the 'Edit' button.
       const row = page.getByRole('row', { name: cueName })
       await row.getByRole('button', { name: '編集' }).click()
 
-      // Update the cue name
+      // Update the cue name.
       await page.getByLabel('演出名').fill(updatedCueName)
       await page.getByRole('button', { name: '保存' }).click()
 
-      // Verify the cue name is updated
-      await expect(page.getByText(updatedCueName)).toBeVisible()
-      await expect(page.getByText(cueName)).not.toBeVisible()
+      // Verify the cue name is updated in the table.
+      await expect(page.getByRole('row', { name: updatedCueName })).toBeVisible()
+      await expect(page.getByRole('row', { name: cueName })).not.toBeVisible()
     })
 
     it('2.3: Delete the cue', async () => {
-      // Find the row and click the 'Delete' button
+      // Find the row and click the 'Delete' button.
       const row = page.getByRole('row', { name: updatedCueName })
       await row.getByRole('button', { name: '削除' }).click()
 
-      // Confirm deletion in the dialog
+      // Confirm deletion in the dialog.
       await page.getByRole('button', { name: 'はい、削除します' }).click()
 
-      // Verify the cue is removed from the table
-      await expect(page.getByText(updatedCueName)).not.toBeVisible()
+      // Verify the cue is removed from the table.
+      await expect(page.getByRole('row', { name: updatedCueName })).not.toBeVisible()
     })
   })
 
   describe('Scenario 3: Real-time Sync Flow', () => {
+    // This test is complex and requires more time.
     it('3.1: Cue execution should sync with the viewer page', async () => {
       const realTimeCueName = `E2E Real-time Test Cue ${Date.now()}`
       const cueColor = '#ff00ff'
       const expectedRgbColor = 'rgb(255, 0, 255)'
 
-      // --- 1. Setup: Create a cue for the test ---
+      // --- 1. Admin Setup: Create a cue for the test ---
       const adminPage = await createPage()
       await adminPage.goto(url('/admin/login'), { waitUntil: 'networkidle' })
       await adminPage.fill('input[name="email"]', process.env.SUPABASE_TEST_EMAIL || '')
       await adminPage.fill('input[name="password"]', process.env.SUPABASE_TEST_PASSWORD || '')
       await adminPage.click('button[type="submit"]')
-      await adminPage.waitForURL('**/admin/cues')
+      await expect(adminPage.getByRole('heading', { name: '演出管理' })).toBeVisible()
 
       await adminPage.getByRole('button', { name: '新規演出を追加' }).click()
       await adminPage.getByLabel('演出名').fill(realTimeCueName)
       await adminPage.getByLabel('種類').selectOption({ label: '単色' })
       await adminPage.getByLabel('値').fill(cueColor)
       await adminPage.getByRole('button', { name: '保存' }).click()
-      await expect(adminPage.getByText(realTimeCueName)).toBeVisible()
+      await expect(adminPage.getByRole('row', { name: realTimeCueName })).toBeVisible()
 
-      // --- 2. Execution ---
-      // Open viewer page and check initial state
+      // --- 2. Viewer Setup & Execution ---
+      // Open viewer page and check initial state.
       const viewerPage = await createPage()
       await viewerPage.goto(url('/'), { waitUntil: 'networkidle' })
-      await expect(viewerPage.locator('body')).toHaveText('Waiting...')
+      await expect(viewerPage.locator('body:has-text("Waiting...")')).toBeVisible()
 
-      // Admin triggers the cue
+      // Admin navigates to On-Air page and triggers the cue.
       await adminPage.goto(url('/admin/onair'), { waitUntil: 'networkidle' })
       await adminPage.getByRole('button', { name: realTimeCueName }).click()
 
       // --- 3. Verification ---
-      // Check if viewer page background color changes
-      await expect(viewerPage.locator('body')).toHaveCSS('background-color', expectedRgbColor, { timeout: 5000 })
+      // Check if viewer page background color changes.
+      await expect(viewerPage.locator('body')).toHaveCSS('background-color', expectedRgbColor, { timeout: 10000 })
 
       // --- 4. Cleanup ---
-      // Delete the created cue
+      // Admin deletes the created cue.
       await adminPage.goto(url('/admin/cues'), { waitUntil: 'networkidle' })
       const row = adminPage.getByRole('row', { name: realTimeCueName })
       await row.getByRole('button', { name: '削除' }).click()
       await adminPage.getByRole('button', { name: 'はい、削除します' }).click()
-      await expect(adminPage.getByText(realTimeCueName)).not.toBeVisible()
+      await expect(adminPage.getByRole('row', { name: realTimeCueName })).not.toBeVisible()
 
-      // Close pages
+      // Close pages.
       await viewerPage.close()
       await adminPage.close()
-    }, 20000) // Increase timeout for this complex test
+    })
   })
 })

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -5,6 +5,6 @@ export default defineVitestConfig({
     globals: true,
     environment: 'nuxt',
     include: ['test/e2e/**/*.spec.ts'],
-    testTimeout: 60000, // Set a longer timeout for E2E tests
+    testTimeout: 60000,
   },
 })

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -2,13 +2,9 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 
 export default defineVitestConfig({
   test: {
-    environment: 'node', // E2E tests run in a Node.js environment
-    testTimeout: 20000, // Increase timeout for E2E tests
     globals: true,
-    setupFiles: [],
+    environment: 'nuxt',
     include: ['test/e2e/**/*.spec.ts'],
-  },
-  define: {
-    'import.meta.vitest': false,
+    testTimeout: 60000, // Set a longer timeout for E2E tests
   },
 })


### PR DESCRIPTION
- E2Eテスト用の設定ファイル `vitest.config.e2e.ts` を追加し、適切な `environment: 'nuxt'` とタイムアウトを設定。
- 管理者認証、演出のCRUD操作、リアルタイム連携の各シナリオに対するE2Eテストを `test/e2e/app.spec.ts` に実装。
- `beforeAll` フックや `expect(...).toBeVisible()` などの安定したテストパターンを採用し、信頼性を向上。
- テストで環境変数を扱うための `dotenv` パッケージが `devDependencies` に含まれていることを確認。